### PR TITLE
Update `isMerged` color code

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -9,7 +9,7 @@ interface TextButton {
 
 function getTextColor(state: string, isMerged: boolean): string {
   if (isMerged) {
-    return '#6f42c1'
+    return '#35dbd9'
   }
 
   if (state === 'closed') {


### PR DESCRIPTION
Hello 

I think the color code of `isMerged` is not readable in dark mode. (see screenshot)

so, I request a small code change. 
- Change `#6f42c1` to `#35dbd9`

thank you :)

<img width="379" alt="image" src="https://user-images.githubusercontent.com/13309303/235352912-fff4fcfd-aa8e-4e18-890e-f6109d7608df.png">

